### PR TITLE
Update MunSeeker_ZZZ_RadioTelescope_Contracts.cfg

### DIFF
--- a/GameData/MunSeeker/ZZZ_RadioTelescope/MunSeeker_ZZZ_RadioTelescope_Contracts.cfg
+++ b/GameData/MunSeeker/ZZZ_RadioTelescope/MunSeeker_ZZZ_RadioTelescope_Contracts.cfg
@@ -82,12 +82,14 @@ CONTRACT_TYPE
     {
         type = Vessel
         requiredValue = false
+        title = You must launch a new telescope.
         targetVessel = [ KerbinTelescope ].Random()
     }
     DATA
     {
         type = CelestialBody
         requiredValue = true
+	title = Your radiotelescope must be in a stable orbit around Kerbin.
         targetBody = [Kerbin ].Random()
     }
 


### PR DESCRIPTION
Fix: The field 'title' is required in for data node values where 'requiredValue' is true.

[LOG 20:22:06.673] [INFO] ContractConfigurator.ContractType: Loading CONTRACT_TYPE: 'KerbinOrbitalTelescopeDeployment'
[ERR 20:22:06.683] ContractConfigurator.ExpressionParser.DataNode: CONTRACT_TYPE 'KerbinOrbitalTelescopeDeployment': targetBody: The field 'title' is required in for data node values where 'requiredValue' is true.  Alternatively, the attribute 'hidden' can be set to true (but be careful - this can cause player confusion if all lines for the contract type show as 'Met' and the contract isn't generating).
[WRN 20:22:06.688] ContractConfigurator.ContractType: CONTRACT_TYPE 'KerbinOrbitalTelescopeDeployment': unexpected attribute 'displayName' found, ignored.
[WRN 20:22:06.688] ContractConfigurator.ContractType: Errors encountered while trying to load CONTRACT_TYPE 'KerbinOrbitalTelescopeDeployment'